### PR TITLE
Fix CodeEditor line numbers

### DIFF
--- a/src/app/components/CodeEditor.tsx
+++ b/src/app/components/CodeEditor.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useRef, KeyboardEvent } from "react";
+import { useState, useRef, useEffect, KeyboardEvent } from "react";
 
 interface CodeEditorProps {
   value: string;
@@ -18,6 +18,12 @@ export default function CodeEditor({
 }: CodeEditorProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [lineCount, setLineCount] = useState(1);
+
+  // Keep line numbers in sync with the initial value
+  useEffect(() => {
+    const lines = value.split("\n").length;
+    setLineCount(lines);
+  }, [value]);
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     const textarea = e.currentTarget;


### PR DESCRIPTION
## Summary
- ensure the CodeEditor initializes line numbers based on the current value

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b990e16083248b6763de4c35f026